### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :item_find, only: [:show, :edit, :update]
+  before_action :redirect, only: [:edit, :update]
+
   def index
     @items = Item.order('created_at DESC')
   end
@@ -18,16 +21,12 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
-    redirect_to action: :index unless user_signed_in? && current_user.id == @item.user_id
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to root_path
     else
@@ -36,6 +35,14 @@ class ItemsController < ApplicationController
   end
 
   private
+
+  def item_find
+    @item = Item.find(params[:id])
+  end
+
+  def redirect
+    redirect_to action: :index unless current_user.id == @item.user_id
+  end
 
   def item_params
     params.require(:item).permit(:image, :product, :genre_id, :text, :condition_id, :price, :charge_id, :area_id,

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
   def index
     @items = Item.order('created_at DESC')
   end
@@ -19,6 +19,20 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+    redirect_to action: :index unless user_signed_in? && current_user.id == @item.user_id
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -129,7 +129,7 @@
     
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,4 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
+
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
@@ -7,13 +6,12 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with( model:@item, local: true) do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
-    <%# 出品画像 %>
+    
+    <%= render 'shared/error_messages', model: f.object %>
+    
+    
     <div class="img-upload">
       <div class="weight-bold-text">
         出品画像
@@ -23,28 +21,25 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
-    <%# /出品画像 %>
-    <%# 商品名と商品説明 %>
+   
     <div class="new-items">
       <div class="weight-bold-text">
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :product, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :text, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
+   
     <div class="items-detail">
       <div class="weight-bold-text">商品の詳細</div>
       <div class="form">
@@ -52,17 +47,15 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:genre_id, Genre.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
+   
     <div class="items-detail">
       <div class="weight-bold-text question-text">
         <span>配送について</span>
@@ -73,22 +66,20 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:charge_id, Charge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:area_id, Area.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:day_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
+    
     <div class="sell-price">
       <div class="weight-bold-text question-text">
         <span>販売価格<br>(¥300〜9,999,999)</span>
@@ -101,7 +92,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -117,9 +108,7 @@ app/assets/stylesheets/items/new.css %>
         </div>
       </div>
     </div>
-    <%# /販売価格 %>
-
-    <%# 注意書き %>
+    
     <div class="caution">
       <p class="sentence">
         <a href="#">禁止されている出品、</a>
@@ -137,13 +126,12 @@ app/assets/stylesheets/items/new.css %>
         に同意したことになります。
       </p>
     </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
+    
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
       <%=link_to 'もどる', "#", class:"back-btn" %>
     </div>
-    <%# /下部ボタン %>
+    
   </div>
   <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
 
     
     <% if user_signed_in? && current_user.id == @item.user_id %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# What
商品情報編集機能の実装
# Why
商品情報編集を可能にするため。また、購入に関わる一部機能に関しては、購入機能実装後に追加実装予定です。

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/ddc086b5402c55e6171bdb7a8203561c
正しく情報を記入すると、商品の情報を編集できる動画
https://gyazo.com/fc2a7cbefdebf9c724ecabaf7514db60
入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://gyazo.com/eda1c4ca9066698e2b9735f0a5ecd787
何も編集せずに更新をしても画像無しの商品にならない動画
https://gyazo.com/9dc2d16d1fb0d7c7601c22a78789918f
ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/8701d197cd199d173f185ca42d67d359
ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/4366e2310b6cf498cf0aaa0b3a5e2dda
商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
https://gyazo.com/c218d902ab14f8302b61c742b49dc0dc